### PR TITLE
Repairs invalid link to `types.proto` in abci/README.md

### DIFF
--- a/abci/README.md
+++ b/abci/README.md
@@ -20,7 +20,7 @@ To get up and running quickly, see the [getting started guide](../docs/app-dev/g
 A detailed description of the ABCI methods and message types is contained in:
 
 - [The main spec](https://github.com/tendermint/spec/blob/master/spec/abci/abci.md)
-- [A protobuf file](./types/types.proto)
+- [A protobuf file](..proto/tendermint/abci/types.proto)
 - [A Go interface](./types/application.go)
 
 ## Protocol Buffers


### PR DESCRIPTION
## Description

Simply changing a link in `abci/README.md` to what I think the intended target was because it was failing with a 404 error. Previously, the link was pointing to `abci/types`, looking for `types.proto`, which appears to be defined in the `proto/tendermint/types` subdirectory
