### PR TITLE
Fix indexing bug

### DIFF
--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -97,7 +97,7 @@ func (txi *TxIndex) AddBatch(b *txindex.Batch) error {
 					return unmarshalErr
 				}
 
-				successful := duplicateCheck.Result.Code == 0
+				successful := duplicateCheck.Result.Code == abci.CodeTypeOK
 
 				// if previously indexed tx is successful, don't do anything and skip the loop
 				if successful {

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -66,6 +66,217 @@ func TestTxIndex(t *testing.T) {
 	assert.True(t, proto.Equal(txResult2, loadedTxResult2))
 }
 
+func TestTxIndexDuplicatePreviouslySuccessful(t *testing.T) {
+	indexer := NewTxIndex(db.NewMemDB())
+
+	var mockTx = types.Tx("MOCK_TX_HASH")
+
+	tx := mockTx
+	txResult := &abci.TxResult{
+		Height: 1,
+		Index:  0,
+		Tx:     tx,
+		Result: abci.ResponseDeliverTx{
+			Data: []byte{0},
+			Code: abci.CodeTypeOK, Log: "should be saved", Events: nil,
+		},
+	}
+	hash := tx.Hash()
+
+	batch := txindex.NewBatch(1)
+	if err := batch.Add(txResult); err != nil {
+		t.Error(err)
+	}
+	err := indexer.AddBatch(batch)
+	require.NoError(t, err)
+
+	loadedTxResult, err := indexer.Get(hash)
+	require.NoError(t, err)
+	assert.True(t, proto.Equal(txResult, loadedTxResult))
+
+	tx2 := mockTx
+	txResult2 := &abci.TxResult{
+		Height: 2,
+		Index:  0,
+		Tx:     tx2,
+		Result: abci.ResponseDeliverTx{
+			Data: []byte{0},
+			Code: abci.CodeTypeOK ^ 1, Log: "should not be saved", Events: nil,
+		},
+	}
+	hash2 := tx2.Hash()
+
+	batch = txindex.NewBatch(1)
+	if err := batch.Add(txResult2); err != nil {
+		t.Error(err)
+	}
+	err = indexer.AddBatch(batch)
+	require.NoError(t, err)
+
+	loadedTxResult2, err := indexer.Get(hash2)
+	require.NoError(t, err)
+
+	fmt.Println(loadedTxResult2.Result.Log)
+	assert.True(t, loadedTxResult2.Result.Log == "should be saved")
+}
+
+func TestTxIndexDuplicatePreviouslyUnsuccessful(t *testing.T) {
+	indexer := NewTxIndex(db.NewMemDB())
+
+	var mockTx = types.Tx("MOCK_TX_HASH")
+
+	tx := mockTx
+	txResult := &abci.TxResult{
+		Height: 1,
+		Index:  0,
+		Tx:     tx,
+		Result: abci.ResponseDeliverTx{
+			Data: []byte{0},
+			Code: abci.CodeTypeOK ^ 1, Log: "foo", Events: nil,
+		},
+	}
+	hash := tx.Hash()
+
+	batch := txindex.NewBatch(1)
+	if err := batch.Add(txResult); err != nil {
+		t.Error(err)
+	}
+	err := indexer.AddBatch(batch)
+	require.NoError(t, err)
+
+	loadedTxResult, err := indexer.Get(hash)
+	require.NoError(t, err)
+	assert.True(t, proto.Equal(txResult, loadedTxResult))
+
+	tx2 := mockTx
+	txResult2 := &abci.TxResult{
+		Height: 2,
+		Index:  0,
+		Tx:     tx2,
+		Result: abci.ResponseDeliverTx{
+			Data: []byte{0},
+			Code: abci.CodeTypeOK, Log: "bar", Events: nil,
+		},
+	}
+	hash2 := tx2.Hash()
+
+	batch = txindex.NewBatch(1)
+	if err := batch.Add(txResult2); err != nil {
+		t.Error(err)
+	}
+	err = indexer.AddBatch(batch)
+	require.NoError(t, err)
+
+	loadedTxResult2, err := indexer.Get(hash2)
+	require.NoError(t, err)
+	assert.True(t, loadedTxResult2.Result.Log == "bar")
+}
+
+func TestTxIndexDuplicateBothUnsuccessful(t *testing.T) {
+	indexer := NewTxIndex(db.NewMemDB())
+
+	var mockTx = types.Tx("MOCK_TX_HASH")
+
+	tx := mockTx
+	txResult := &abci.TxResult{
+		Height: 1,
+		Index:  0,
+		Tx:     tx,
+		Result: abci.ResponseDeliverTx{
+			Data: []byte{0},
+			Code: abci.CodeTypeOK ^ 1, Log: "foo", Events: nil,
+		},
+	}
+	hash := tx.Hash()
+
+	batch := txindex.NewBatch(1)
+	if err := batch.Add(txResult); err != nil {
+		t.Error(err)
+	}
+	err := indexer.AddBatch(batch)
+	require.NoError(t, err)
+
+	loadedTxResult, err := indexer.Get(hash)
+	require.NoError(t, err)
+	assert.True(t, proto.Equal(txResult, loadedTxResult))
+
+	tx2 := mockTx
+	txResult2 := &abci.TxResult{
+		Height: 2,
+		Index:  0,
+		Tx:     tx2,
+		Result: abci.ResponseDeliverTx{
+			Data: []byte{0},
+			Code: abci.CodeTypeOK ^ 1, Log: "bar", Events: nil,
+		},
+	}
+	hash2 := tx2.Hash()
+
+	batch = txindex.NewBatch(1)
+	if err := batch.Add(txResult2); err != nil {
+		t.Error(err)
+	}
+	err = indexer.AddBatch(batch)
+	require.NoError(t, err)
+
+	loadedTxResult2, err := indexer.Get(hash2)
+	require.NoError(t, err)
+	assert.True(t, loadedTxResult2.Result.Log == "bar")
+}
+
+// This case cannot happen technically, but exists just to check the code sanity
+func TestTxIndexDuplicateBothSuccessful(t *testing.T) {
+	indexer := NewTxIndex(db.NewMemDB())
+
+	var mockTx = types.Tx("MOCK_TX_HASH")
+
+	tx := mockTx
+	txResult := &abci.TxResult{
+		Height: 1,
+		Index:  0,
+		Tx:     tx,
+		Result: abci.ResponseDeliverTx{
+			Data: []byte{0},
+			Code: abci.CodeTypeOK, Log: "foo", Events: nil,
+		},
+	}
+	hash := tx.Hash()
+
+	batch := txindex.NewBatch(1)
+	if err := batch.Add(txResult); err != nil {
+		t.Error(err)
+	}
+	err := indexer.AddBatch(batch)
+	require.NoError(t, err)
+
+	loadedTxResult, err := indexer.Get(hash)
+	require.NoError(t, err)
+	assert.True(t, proto.Equal(txResult, loadedTxResult))
+
+	tx2 := mockTx
+	txResult2 := &abci.TxResult{
+		Height: 2,
+		Index:  0,
+		Tx:     tx2,
+		Result: abci.ResponseDeliverTx{
+			Data: []byte{0},
+			Code: abci.CodeTypeOK, Log: "bar", Events: nil,
+		},
+	}
+	hash2 := tx2.Hash()
+
+	batch = txindex.NewBatch(1)
+	if err := batch.Add(txResult2); err != nil {
+		t.Error(err)
+	}
+	err = indexer.AddBatch(batch)
+	require.NoError(t, err)
+
+	loadedTxResult2, err := indexer.Get(hash2)
+	require.NoError(t, err)
+	assert.True(t, loadedTxResult2.Result.Log == "bar")
+}
+
 func TestTxSearch(t *testing.T) {
 	indexer := NewTxIndex(db.NewMemDB())
 


### PR DESCRIPTION
## Description
This PR addresses the problem of overwriting the txhash index of successful transactions with failed transactions in later blocks. In such case, txhash query will return failed transaction.

Example case:
https://lcd.terra.dev/cosmos/tx/v1beta1/txs/6053BE407FFBCAC836AA94C6D7A7A81C7655A138D112C3DD2F46496FCB98FBE4

The above tx was indexed at height 7573592. However, we have a successful transaction with the same txhash.
https://check-tx.vercel.app/api/check-tx?height=7571561&txhash=6053BE407FFBCAC836AA94C6D7A7A81C7655A138D112C3DD2F46496FCB98FBE4